### PR TITLE
Set content type properly and set isBase64Encoded on response

### DIFF
--- a/lambda.rb
+++ b/lambda.rb
@@ -14,7 +14,8 @@ def handler(event:, context:)
     "QUERY_STRING" => event['queryStringParameters'] || "",
     "SERVER_NAME" => "localhost",
     "SERVER_PORT" => 443,
-    
+    "CONTENT_TYPE" => event['headers']['content-type'],
+
     "rack.version" => Rack::VERSION,
     "rack.url_scheme" => "https",
     "rack.input" => StringIO.new(event['body'] || ""),
@@ -39,6 +40,7 @@ def handler(event:, context:)
     # https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
     response = {
       "statusCode" => status,
+      "isBase64Encoded" => false,
       "headers" => headers,
       "body" => body_content
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I was unable to get the current sample working via an ALB. The health check would fail every time, this turned out to be that the response needs to have `isBase64Encoded` set (to `false`). This either defaults to false or is required for API Gateway as well. I also discovered determining the request content type doesn't work (ex: `request.content_type` in sinatra) because the rack env `CONTENT_TYPE` wasn't set. Both these changes are in the `lambda.rb` file.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
