### PR TITLE
gitignore RVM config of those who are contributing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ruby-gemset
+.ruby-version


### PR DESCRIPTION
*Description of changes:*


Given I'm a new contributor who wants to clone `aws-samples/serverless-sinatra-sample` 
And I use [RVM](https://rvm.io/) or [RBENV](https://github.com/rbenv/rbenv) 
Then I would have to create .ruby-version .ruby-gemset in order to `bundle install`

Given I want to contribute new PR 
Then I don't want to accidentally commit  my .ruby-version & .ruby-gemset


...or alternatively we can keep the .ruby-version & .ruby-gemset commited in the project by default dictating what ruby version in the project requiring . In that case pls Close this PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
