### PR TITLE
Save params to own fields in Dynamo DB + missing tests & better Sinatra practices

### DIFF
--- a/app/server.rb
+++ b/app/server.rb
@@ -1,6 +1,14 @@
 require 'sinatra'
 require 'aws-record'
 
+before do
+  if request.body.size > 0
+    request.body.rewind
+    @params = Sinatra::IndifferentHash.new
+    @params.merge!(JSON.parse(request.body.read))
+  end
+end
+
 ##################################
 # For the index page
 ##################################
@@ -44,7 +52,7 @@ get '/api/feedback' do
   ret = []
   items = FeedbackServerlessSinatraTable.scan()
   items.each do |r|
-    item = { :ts => r.ts, :data => r.data }
+    item = { :ts => r.ts, :name => r.name, :feedback => r.feedback }
     ret.push(item)
   end
   ret.sort { |a, b| a[:ts] <=> b[:ts] }.to_json
@@ -52,6 +60,7 @@ end
 
 post '/api/feedback' do
   content_type :json
+
   item = FeedbackServerlessSinatraTable.new(id: SecureRandom.uuid, ts: Time.now)
   item.name = params[:name]
   item.feedback = params[:feedback]

--- a/app/server.rb
+++ b/app/server.rb
@@ -49,18 +49,15 @@ end
 
 get '/api/feedback' do
   content_type :json
-  ret = []
   items = FeedbackServerlessSinatraTable.scan()
-  items.each do |r|
-    item = { :ts => r.ts, :name => r.name, :feedback => r.feedback }
-    ret.push(item)
-  end
-  ret.sort { |a, b| a[:ts] <=> b[:ts] }.to_json
+  items
+    .map { |r| { :ts => r.ts, :name => r.name, :feedback => r.feedback } }
+    .sort { |a, b| a[:ts] <=> b[:ts] }
+    .to_json
 end
 
 post '/api/feedback' do
   content_type :json
-
   item = FeedbackServerlessSinatraTable.new(id: SecureRandom.uuid, ts: Time.now)
   item.name = params[:name]
   item.feedback = params[:feedback]

--- a/app/server.rb
+++ b/app/server.rb
@@ -30,7 +30,8 @@ end
 class FeedbackServerlessSinatraTable
   include Aws::Record
   string_attr :id, hash_key: true
-  string_attr :data
+  string_attr :name
+  string_attr :feedback
   epoch_time_attr :ts
 end
 
@@ -51,8 +52,10 @@ end
 
 post '/api/feedback' do
   content_type :json
-  body = env["rack.input"].gets
-  item = FeedbackServerlessSinatraTable.new(id: SecureRandom.uuid, ts: Time.now, data: body)
+  item = FeedbackServerlessSinatraTable.new(id: SecureRandom.uuid, ts: Time.now)
+  item.name = params[:name]
+  item.feedback = params[:feedback]
   item.save! # raise an exception if save fails
+
   item.to_json
 end

--- a/app/views/feedback.erb
+++ b/app/views/feedback.erb
@@ -54,12 +54,11 @@
         });
       });
     }
-    function insertListItem(i) {
-      let data = JSON.parse(i.data);
+    function insertListItem(data) {
       let newItem = '<a href="#" class="list-group-item list-group-item-action flex-column align-items-start">' +
     	  '<div class="d-flex w-100 justify-content-between">' +
           '<h5 class="mb-1" style="margin:0 auto;">Name: ' + data.name + '</h5>' + 
-          '<small>Time: ' + i.ts + '</small>' +
+          '<small>Time: ' + data.ts + '</small>' +
           '</div>' +
           '<p class="mb-1">Feedback: ' + data.feedback + '</p></a>';
       $("#lists").prepend(newItem);

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -16,11 +16,10 @@ describe 'HelloWorld Service' do
   it "should return successfully on POST" do
     post '/hello-world'
     expect(last_response).to be_ok
-    json_result = JSON.parse(last_response.body)
     expect(json_result["Output"]).to eq("Hello World!")
   end
 
-  it "should POST params to feedback endpoint with success" do
+  it "should POST params to API feedback endpoint with success" do
     expect(stub_client)
       .to receive(:put_item)
       .with({
@@ -37,5 +36,21 @@ describe 'HelloWorld Service' do
     api_gateway_post('/api/feedback', { name: "Tomas", feedback: "AWS Lambda + Ruby == <3" })
 
     expect(last_response).to be_ok
+  end
+
+  it "should successfuly GET items from API feedback endpoint in right order" do
+    stub_client.stub_responses(:scan, :items => [
+      {'name' => 'Zdenka', "ts" => 2345678, "feedback" => "Halestorm"},
+      {'name' => 'Tomas',  "ts" => 1234567, "feedback" => "Trivium"},
+      {'name' => 'xiangshen', "ts" => 5678901, "feedback" => "Awesome !"},
+    ])
+
+    get '/api/feedback'
+    expect(last_response).to be_ok
+    expect(json_result).to match_array([
+      { "name" => "Tomas",    "feedback"=>"Trivium",   "ts"=> be_kind_of(String)},
+      { "name" => "Zdenka",   "feedback"=>"Halestorm", "ts"=> be_kind_of(String)},
+      { "name" => "xiangshen","feedback"=>"Awesome !", "ts"=> be_kind_of(String)}
+    ])
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 
-set :environment, :test
-
 # Tests for server.rb
 describe 'HelloWorld Service' do
   include Rack::Test::Methods
@@ -36,7 +34,7 @@ describe 'HelloWorld Service' do
         :table_name=>"FeedbackServerlessSinatraTable"})
       .and_call_original
 
-    post '/api/feedback', name: "Tomas", feedback: "AWS Lambda + Ruby == <3"
+    api_gateway_post('/api/feedback', { name: "Tomas", feedback: "AWS Lambda + Ruby == <3" })
 
     expect(last_response).to be_ok
   end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,15 +1,10 @@
-require_relative '../app/server.rb'
-require 'rack/test'
+require 'spec_helper'
 
 set :environment, :test
 
 # Tests for server.rb
 describe 'HelloWorld Service' do
   include Rack::Test::Methods
-
-  def app
-    Sinatra::Application
-  end
 
   # Test for HTTP GET for URL-matching pattern '/'
   it "should return successfully on GET" do
@@ -25,5 +20,24 @@ describe 'HelloWorld Service' do
     expect(last_response).to be_ok
     json_result = JSON.parse(last_response.body)
     expect(json_result["Output"]).to eq("Hello World!")
+  end
+
+  it "should POST params to feedback endpoint with success" do
+    expect(stub_client)
+      .to receive(:put_item)
+      .with({
+        :condition_expression=>be_kind_of(String),
+        :expression_attribute_names=>be_kind_of(Hash),
+        :item=>
+         {"feedback"=>"AWS Lambda + Ruby == <3",
+          "id"=>be_kind_of(String),
+          "name"=>"Tomas",
+          "ts"=>be_within(3).of(Time.now.to_i)},
+        :table_name=>"FeedbackServerlessSinatraTable"})
+      .and_call_original
+
+    post '/api/feedback', name: "Tomas", feedback: "AWS Lambda + Ruby == <3"
+
+    expect(last_response).to be_ok
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+require_relative '../app/server.rb'
+require 'rack/test'
+
+RSpec.configure do |config|
+  config.before(:each) do
+    FeedbackServerlessSinatraTable.configure_client(client: stub_client)
+  end
+end
+
+def app
+  Sinatra::Application
+end
+
+def stub_client
+  @stub_client ||= begin
+    Aws::DynamoDB::Client.new(stub_responses: true) # don't send real calls to DynamoDB in test env
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require_relative '../app/server.rb'
 require 'rack/test'
 
+set :environment, :test
+
 RSpec.configure do |config|
   config.before(:each) do
     FeedbackServerlessSinatraTable.configure_client(client: stub_client)
@@ -15,4 +17,15 @@ def stub_client
   @stub_client ||= begin
     Aws::DynamoDB::Client.new(stub_responses: true) # don't send real calls to DynamoDB in test env
   end
+end
+
+# We could use native RSpec `post '/endpoint', param1: 'foo', param2: 'bar'
+# But this method better replicates how AWS API Gateway forwards the request
+# to our AWS Lamda function: In './lambda.rb' needs to reset `rack.input` with
+# JSON string Lambda event body.
+def api_gateway_post(path, params)
+  api_gateway_body_fwd = params.to_json
+  rack_input = StringIO.new(api_gateway_body_fwd)
+
+  post path, real_params = {}, {"rack.input" => rack_input}
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,3 +29,7 @@ def api_gateway_post(path, params)
 
   post path, real_params = {}, {"rack.input" => rack_input}
 end
+
+def json_result
+  JSON.parse(last_response.body)
+end


### PR DESCRIPTION
*Issue #, if available:*

not applicable

*Description of changes:*

* contains missing tests for 
  * POST '/api/feedback' 
  * GET ''/api/feedback"
  * stubs are directly inspired from https://github.com/aws/aws-sdk-ruby-record/blob/master/spec/aws-record/record/item_collection_spec.rb
* fix Sinatra `params` to corespond implementation of `ENV["rack.input"]  (`lambda.rb` is passing API gateway requests via it)
* original implementation was writing to  dynamo DB entire body to  field "data" which was stringified JSON, my proposed implementation is writing to separate Dynamo DB fields "name" and "feedback"
* fix views & JS according to new refactor
* introduce `spec/spec_helper.rb` which is better practice for RSpec
* ensure RSpec test will not write items to Dynamo DB

![screenshot from 2018-12-05 15-48-38](https://user-images.githubusercontent.com/721990/49536523-08864e00-f8c7-11e8-8f13-9890578f630d.png)
![screenshot from 2018-12-05 19-50-56](https://user-images.githubusercontent.com/721990/49536575-2bb0fd80-f8c7-11e8-93e6-94dad14253cb.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
