### PR TITLE
Rakefile for running tests with

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'json'
 gem 'rack'
 gem 'rack-contrib'
 gem 'aws-record'
+gem 'rake'
 
 # These are the dependencies that are used only for unit tests.
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rake (12.3.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -54,6 +55,7 @@ DEPENDENCIES
   rack
   rack-contrib
   rack-test
+  rake
   rspec
   sinatra
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new :specs do |task|
+  task.pattern = Dir['spec/**/*_spec.rb']
+end
+
+task :default => ['specs']


### PR DESCRIPTION
*Issue #, if available:*

not applicable

*Description of changes:*

In Ruby world there is a good practice to configure default  [Rake](https://github.com/ruby/rake/blob/master/lib/rake.rb) task `rake` to run the tests. This is so that CI or anyone who clones the project  run the task without knowing if it's RSpec or MiniTest testnig framework

so in order to run tests all one need to do is run `rake` 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
