### PR TITLE
Use Ruby 2 feature __dir__; and style details

### DIFF
--- a/lambda.rb
+++ b/lambda.rb
@@ -19,42 +19,43 @@ require 'base64'
 
 # Global object that responds to the call method. Stay outside of the handler
 # to take advantage of container reuse
-$app ||= Rack::Builder.parse_file("#{File.dirname(__FILE__)}/app/config.ru").first
+$app ||= Rack::Builder.parse_file("#{__dir__}/app/config.ru").first
 
 def handler(event:, context:)
   # Check if the body is base64 encoded. If it is, try to decode it
-  if event["isBase64Encoded"]
-    body = Base64.decode64(event['body'])
-  else
-    body = event['body']
-  end
+  body = 
+    if event['isBase64Encoded']
+      Base64.decode64(event['body'])
+    else
+      event['body']
+    end
   # Rack expects the querystring in plain text, not a hash
   querystring = Rack::Utils.build_query(event['queryStringParameters']) if event['queryStringParameters']
   # Environment required by Rack (http://www.rubydoc.info/github/rack/rack/file/SPEC)
   env = {
-    "REQUEST_METHOD" => event['httpMethod'],
-    "SCRIPT_NAME" => "",
-    "PATH_INFO" => event['path'] || "",
-    "QUERY_STRING" => querystring || "",
-    "SERVER_NAME" => "localhost",
-    "SERVER_PORT" => 443,
-    "CONTENT_TYPE" => event['headers']['content-type'],
+    'REQUEST_METHOD' => event['httpMethod'],
+    'SCRIPT_NAME' => '',
+    'PATH_INFO' => event['path'] || '',
+    'QUERY_STRING' => querystring || '',
+    'SERVER_NAME' => 'localhost',
+    'SERVER_PORT' => 443,
+    'CONTENT_TYPE' => event['headers']['content-type'],
 
-    "rack.version" => Rack::VERSION,
-    "rack.url_scheme" => "https",
-    "rack.input" => StringIO.new(body || ""),
-    "rack.errors" => $stderr,
+    'rack.version' => Rack::VERSION,
+    'rack.url_scheme' => 'https',
+    'rack.input' => StringIO.new(body || ''),
+    'rack.errors' => $stderr,
   }
   # Pass request headers to Rack if they are available
   unless event['headers'].nil?
-    event['headers'].each{ |key, value| env["HTTP_#{key}"] = value }
+    event['headers'].each { |key, value| env["HTTP_#{key}"] = value }
   end
 
   begin
     # Response from Rack must have status, headers and body
     status, headers, body = $app.call(env)
 
-    # body is an array. We simply combine all the items to a single string
+    # body is an array. We combine all the items to a single string
     body_content = ""
     body.each do |item|
       body_content += item.to_s
@@ -63,19 +64,19 @@ def handler(event:, context:)
     # We return the structure required by AWS API Gateway since we integrate with it
     # https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
     response = {
-      "statusCode" => status,
-      "headers" => headers,
-      "body" => body_content
+      'statusCode' => status,
+      'headers' => headers,
+      'body' => body_content
     }
-    if event["requestContext"].has_key?("elb")
-      # Required if we use application load balancer instead of API GW
-      response["isBase64Encoded"] = false
+    if event['requestContext'].key?('elb')
+      # Required if we use Application Load Balancer instead of API Gateway
+      response['isBase64Encoded'] = false
     end
   rescue Exception => msg
     # If there is any exception, we return a 500 error with an error message
     response = {
-      "statusCode" => 500,
-      "body" => msg
+      'statusCode' => 500,
+      'body' => msg
     }
   end
   # By default, the response serializer will call #to_json for us


### PR DESCRIPTION
*Description of changes:*

This PR changes stylistic details, and Ruby style things:

  - Use `__dir__` instead of `File.dirname(__FILE__)`
  - In code comments, spell out the words for ALB and API GW
  - In code comments: omit a "simply"
  - Ruby: use single quotes when possible
  - Ruby: prefer key? over has_key?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
