### PR TITLE
Gemfile: Update dependency aws-sdk-dynamodb to 1.21.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,16 +2,16 @@ GEM
   remote: http://rubygems.org/
   specs:
     aws-eventstream (1.0.1)
-    aws-partitions (1.114.0)
-    aws-record (2.1.2)
-      aws-sdk-dynamodb (~> 1.0)
-    aws-sdk-core (3.38.0)
+    aws-partitions (1.139.0)
+    aws-record (2.3.0)
+      aws-sdk-dynamodb (~> 1.18)
+    aws-sdk-core (3.46.1)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-dynamodb (1.16.0)
-      aws-sdk-core (~> 3, >= 3.26.0)
+    aws-sdk-dynamodb (1.21.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
     diff-lcs (1.3)
@@ -62,4 +62,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
*Description of changes:*

Running the RSpec test printed a warning about using an outdated Ruby concept (BigDecimal.new)

```
.../Users/olle/.rvm/gems/ruby-2.6.1/gems/aws-sdk-dynamodb-1.16.0/lib/aws-sdk-dynamodb/attribute_value.rb:79: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Users/olle/.rvm/gems/ruby-2.6.1/gems/aws-sdk-dynamodb-1.16.0/lib/aws-sdk-dynamodb/attribute_value.rb:79: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
/Users/olle/.rvm/gems/ruby-2.6.1/gems/aws-sdk-dynamodb-1.16.0/lib/aws-sdk-dynamodb/attribute_value.rb:79: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```

By upgrading that dependency, the warning is no longer output on running the tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
