### PR TITLE
update to handle multi-value response headers 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .ruby-gemset
 .ruby-version
+/.bundle/
+/vendor/bundle/
+serverless-output.yaml

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'sinatra'
+gem 'sinatra-contrib'
 gem 'json'
 gem 'rack'
 gem 'rack-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,11 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     aws-eventstream (1.0.1)
     aws-partitions (1.139.0)
     aws-record (2.3.0)
@@ -14,9 +19,15 @@ GEM
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
+    backports (3.13.0)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.1.0)
+    minitest (5.11.3)
+    multi_json (1.13.1)
     mustermann (1.0.3)
     rack (2.0.6)
     rack-contrib (2.1.0)
@@ -45,7 +56,18 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.4)
       tilt (~> 2.0)
+    sinatra-contrib (2.0.4)
+      activesupport (>= 4.0.0)
+      backports (>= 2.8.2)
+      multi_json
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.4)
+      sinatra (= 2.0.4)
+      tilt (>= 1.3, < 3)
+    thread_safe (0.3.6)
     tilt (2.0.8)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -60,6 +82,7 @@ DEPENDENCIES
   rspec
   rubysl-base64
   sinatra
+  sinatra-contrib
 
 BUNDLED WITH
    1.17.3

--- a/app/server.rb
+++ b/app/server.rb
@@ -1,4 +1,5 @@
 require 'sinatra'
+require 'sinatra/cookies'
 require 'aws-record'
 
 before do
@@ -27,6 +28,15 @@ end
 post '/hello-world' do
     content_type :json
     { :Output => 'Hello World!' }.to_json
+end
+
+##################################
+# Cookies example
+##################################
+get '/cookies' do
+  cookies[:TestCookie1] = "TestCookie1 Value"
+  cookies[:TestCookie2] = "TestCookie2 Value"
+  erb :cookies
 end
 
 ##################################

--- a/app/views/cookies.erb
+++ b/app/views/cookies.erb
@@ -1,0 +1,4 @@
+<h1>Cookies</h1>
+<div>- from SINATRA on AWS Lambda</div>
+<br>
+<div>Use your browser developer tools to check that cookies were sent back with this response.</div>

--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -6,3 +6,4 @@
 <br>
 <div>Also checkout the API example: <a href="hello-world">Hello World</a></div>
 <div>And a web app example: <a href="feedback">Feedback</a></div>
+<div>And a cookie example: <a href="cookies">Cookies</a></div>

--- a/lambda.rb
+++ b/lambda.rb
@@ -60,12 +60,15 @@ def handler(event:, context:)
     body.each do |item|
       body_content += item.to_s
     end
+    
+    # Setup headers to accomodate mutliValueHeaders
+    headers.each { |k, v| headers[k] = headers[k] = v.split("\n") }
 
     # We return the structure required by AWS API Gateway since we integrate with it
     # https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
     response = {
       'statusCode' => status,
-      'headers' => headers,
+      'multiValueHeaders' => headers,
       'body' => body_content
     }
     if event['requestContext'].key?('elb')

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pp'
 
 # Tests for server.rb
 describe 'HelloWorld Service' do
@@ -10,6 +11,14 @@ describe 'HelloWorld Service' do
     expect(last_response).to be_ok
     json_result = JSON.parse(last_response.body)
     expect(json_result["Output"]).to eq("Hello World!")
+  end
+  
+  # Test for cookies in HTTP response 
+  it "should return cookies in HTTP response" do
+    cookies = "TestCookie1=TestCookie1+Value; domain=example.org; path=/; HttpOnly\nTestCookie2=TestCookie2+Value; domain=example.org; path=/; HttpOnly"
+    get '/cookies'
+    expect(last_response).to be_ok
+    expect(last_response.headers['Set-Cookie']).to eq(cookies)
   end
 
   # Test for HTTP POST for URL-matching pattern '/'


### PR DESCRIPTION
Description of changes:
The driver for these changes is to update the example so that it functions properly when dealing with multi-value headers in the response. Setting multiple cookies (which should generate multiple "Set-Cookie" headers) exercises that functionality. The Sinatra app was extended to show off how cookies can be set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
