### PR TITLE
Improve lambda<->rack interface adherence to Rack's SPEC.

### DIFF
--- a/lambda.rb
+++ b/lambda.rb
@@ -20,40 +20,52 @@ require 'base64'
 # Global object that responds to the call method. Stay outside of the handler
 # to take advantage of container reuse
 $app ||= Rack::Builder.parse_file("#{__dir__}/app/config.ru").first
+ENV['RACK_ENV'] ||= 'production'
 
-def handler(event:, context:)
+
+def lambda_handler(event:, context:)
   # Check if the body is base64 encoded. If it is, try to decode it
-  body = 
-    if event['isBase64Encoded']
-      Base64.decode64(event['body'])
-    else
-      event['body']
-    end
+  body = if event['isBase64Encoded']
+    Base64.decode64 event['body']
+  else
+    event['body']
+  end || ''
+
   # Rack expects the querystring in plain text, not a hash
-  querystring = Rack::Utils.build_query(event['queryStringParameters']) if event['queryStringParameters']
+  headers = event.fetch 'headers', {}
+
   # Environment required by Rack (http://www.rubydoc.info/github/rack/rack/file/SPEC)
   env = {
-    'REQUEST_METHOD' => event['httpMethod'],
+    'REQUEST_METHOD' => event.fetch('httpMethod'),
     'SCRIPT_NAME' => '',
-    'PATH_INFO' => event['path'] || '',
-    'QUERY_STRING' => querystring || '',
-    'SERVER_NAME' => 'localhost',
-    'SERVER_PORT' => 443,
-    'CONTENT_TYPE' => event['headers']['content-type'],
+    'PATH_INFO' => event.fetch('path', ''),
+    'QUERY_STRING' => Rack::Utils.build_query(event['queryStringParameters'] || {}),
+    'SERVER_NAME' => headers.fetch('Host', 'localhost'),
+    'SERVER_PORT' => headers.fetch('X-Forwarded-Port', 443).to_s,
 
     'rack.version' => Rack::VERSION,
-    'rack.url_scheme' => 'https',
-    'rack.input' => StringIO.new(body || ''),
+    'rack.url_scheme' => headers.fetch('CloudFront-Forwarded-Proto') { headers.fetch('X-Forwarded-Proto', 'https') },
+    'rack.input' => StringIO.new(body),
     'rack.errors' => $stderr,
   }
+
   # Pass request headers to Rack if they are available
-  unless event['headers'].nil?
-    event['headers'].each { |key, value| env["HTTP_#{key}"] = value }
+  headers.each_pair do |key, value|
+    # 'CloudFront-Forwarded-Proto' => 'CLOUDFRONT_FORWARDED_PROTO'
+    # Content-Type and Content-Length are handled specially per the Rack SPEC linked above.
+    name = key.upcase.gsub '-', '_'
+    header = case name
+      when 'CONTENT_TYPE', 'CONTENT_LENGTH'
+        name
+      else
+        "HTTP_#{name}"
+    end
+    env[header] = value.to_s
   end
 
   begin
     # Response from Rack must have status, headers and body
-    status, headers, body = $app.call(env)
+    status, headers, body = $app.call env
 
     # body is an array. We combine all the items to a single string
     body_content = ""
@@ -68,17 +80,18 @@ def handler(event:, context:)
       'headers' => headers,
       'body' => body_content
     }
-    if event['requestContext'].key?('elb')
+    if event['requestContext'].has_key?('elb')
       # Required if we use Application Load Balancer instead of API Gateway
       response['isBase64Encoded'] = false
     end
-  rescue Exception => msg
-    # If there is any exception, we return a 500 error with an error message
+  rescue Exception => exception
+    # If there is _any_ exception, we return a 500 error with an error message
     response = {
       'statusCode' => 500,
-      'body' => msg
+      'body' => exception.message
     }
   end
+
   # By default, the response serializer will call #to_json for us
   response
 end


### PR DESCRIPTION
* Default RACK_ENV to `production`.
* HTTP header names must be capitalized.
* `CONTENT_TYPE` and `CONTENT_LENGTH` lack `HTTP_` prefix.
* Don't hard-code server name, port, or scheme, when they are available from the Lambda event.
