### PR TITLE
Fix query strings with special chars

### DIFF
--- a/lambda.rb
+++ b/lambda.rb
@@ -39,7 +39,7 @@ def handler(event:, context:)
     'REQUEST_METHOD' => event.fetch('httpMethod'),
     'SCRIPT_NAME' => '',
     'PATH_INFO' => event.fetch('path', ''),
-    'QUERY_STRING' => Rack::Utils.build_query(event['queryStringParameters'] || {}),
+    'QUERY_STRING' => (event['queryStringParameters'] || {}).map { |k,v| "#{k}=#{v}" }.join('&'),
     'SERVER_NAME' => headers.fetch('Host', 'localhost'),
     'SERVER_PORT' => headers.fetch('X-Forwarded-Port', 443).to_s,
 


### PR DESCRIPTION
Rack::Util.build_query assumes the input hash is not escaped.  
In lambda (certainly where we see it), the query string is
already escaped, so anything with a special character in is
broken.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
